### PR TITLE
 feat(orderbook): switch from polling to WebSocket for real-time updates

### DIFF
--- a/apps/web/app/trade/_components/TradeConsole/index.tsx
+++ b/apps/web/app/trade/_components/TradeConsole/index.tsx
@@ -14,7 +14,7 @@ const TradeConsole = ({ tokenPair, mode }: { tokenPair: string; mode: string }) 
           <TradingViewWidget tokenPair={filterTokenPair} />
         </div>
 
-        <div className="bg-[#161616] min-h-[250px] lg:row-span-2 rounded-sm">
+        <div className="bg-[#161616] min-h-[250px] lg:row-span-2 rounded-sm" suppressHydrationWarning={true}>
           <OrderBook tokenPair={tokenPair} />
         </div>
 

--- a/apps/web/app/trade/_components/orderBook/page.tsx
+++ b/apps/web/app/trade/_components/orderBook/page.tsx
@@ -1,7 +1,9 @@
 "use client";
+
 import OrderBookComponent from "@/components/global/order-book";
 import { getOrderBookData } from "@/lib/api/market-api";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
 export type OrderBookSide = [string, string][];
 export interface OrderBookData {
@@ -9,23 +11,48 @@ export interface OrderBookData {
   asks: OrderBookSide;
 }
 
-type data = {
+type ResponseData = {
   status: string;
   data: OrderBookData;
 };
 
 const OrderBook = ({ tokenPair }: { tokenPair: string }) => {
-  const { data } = useSuspenseQuery<data>({
+  const { data: initialData } = useSuspenseQuery<ResponseData>({
     queryKey: ["orderBookData", tokenPair],
     queryFn: () => getOrderBookData(tokenPair),
-    refetchInterval: 4000,
   });
+
+  const [liveData, setLiveData] = useState<OrderBookData | null>(null);
+
+  useEffect(() => {
+    const normalizedToken = tokenPair.split("_").join("").toLowerCase();
+    const ws = new WebSocket(`${process.env.NEXT_PUBLIC_ORDER_SERVICE}/stream/orderbook?pair=${tokenPair}`);
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data[normalizedToken]) {
+          setLiveData(data[normalizedToken]);
+        }
+      } catch (err) {
+        console.error("WebSocket error:", err);
+      }
+    };
+
+    ws.onerror = (err) => {
+      console.error("WebSocket error:", err);
+    };
+
+    return () => ws.close();
+  }, [tokenPair]);
+
+  const orderBook = liveData || initialData.data;
 
   return (
     <div className="bg-[#161616] flex items-center justify-center h-full w-full rounded-md">
       <OrderBookComponent
-        bids={data?.data?.bids || []}
-        asks={data?.data?.asks || []}
+        bids={orderBook?.bids || []}
+        asks={orderBook?.asks || []}
         tokenPair={tokenPair}
         lastPrice="2398.71"
       />

--- a/apps/web/components/global/MarketTable/columns.tsx
+++ b/apps/web/components/global/MarketTable/columns.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import Image from "next/image";
 import type { tokenMarket } from "./index";
 import numeral from "numeral";
-import { customFormat } from "@/utils/adjustDecimal";
 
 export const columns: ColumnDef<tokenMarket>[] = [
   {
@@ -24,7 +23,7 @@ export const columns: ColumnDef<tokenMarket>[] = [
       );
     },
     cell: ({ row }) => (
-      <div className="capitalize flex items-center gap-2 w-[180px] lg:w-full ">
+      <div className="capitalize flex items-center gap-2 w-[180px] lg:w-full">
         <Image
           src={row.original.icon}
           alt={row.getValue("name")}
@@ -49,11 +48,13 @@ export const columns: ColumnDef<tokenMarket>[] = [
       );
     },
     cell: ({ row }) => (
-      <div>
-        {Number(row.getValue("price")).toLocaleString("en-US", {
-          style: "currency",
-          currency: "USD",
-        })}
+      <div className="w-full flex justify-end">
+        <div className="w-full lg:w-[128px] overflow-x-auto">
+          {Number(row.getValue("price")).toLocaleString("en-US", {
+            style: "currency",
+            currency: "USD",
+          })}
+        </div>
       </div>
     ),
   },

--- a/packages/order-service/src/services/price-service/volumeMcap.ts
+++ b/packages/order-service/src/services/price-service/volumeMcap.ts
@@ -37,9 +37,9 @@ type CoinMarket = {
 export const fetchVolumeMcap = async (volumeMcap: string) => {
   try {
     const response = await fetch(`https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${volumeMcap}`);
-    const data: CoinMarket[] = await response.json();
+    const data: CoinMarket[] = (await response.json()) || [];
 
-    if (!data) return;
+    if (data.length === 0) return;
 
     data?.map((token) => {
       const tokenName = getTokenName(token.symbol);

--- a/packages/order-service/src/services/websockets/index.ts
+++ b/packages/order-service/src/services/websockets/index.ts
@@ -1,0 +1,181 @@
+import { WebSocketServer, WebSocket } from "ws";
+import { orderBooksStore } from "../../store/orderBookStore";
+import { TokenPriceStore } from "../../store/tokenPriceStore";
+import { getTokenName, tokenInfo } from "@paperdex/lib";
+import { parse } from "url";
+
+// export const handlePriceStream = (wss: WebSocketServer) => {
+//   const clients = new Set<WebSocket>();
+
+//   wss.on("connection", (ws) => {
+//     console.log("Client connected to /stream/orderbook");
+//     clients.add(ws);
+
+//     ws.send(JSON.stringify({ message: "Welcome to orderbook stream!" }));
+
+//     ws.on("close", () => {
+//       clients.delete(ws);
+//       console.log("Client disconnected from /stream/orderbook");
+//     });
+
+//     ws.on("error", (err) => {
+//       console.error("WebSocket error:", err);
+//     });
+//   });
+
+//   setInterval(() => {
+//     const data = JSON.stringify(TokenPriceStore);
+//     for (const client of clients) {
+//       if (client.readyState === client.OPEN) {
+//         client.send(data);
+//       }
+//     }
+//   }, 1000);
+// };
+
+type ClientWithPagination = {
+  socket: WebSocket;
+  pageIndex: number;
+  pageSize: number;
+};
+
+export const handlePriceStream = (wss: WebSocketServer) => {
+  const clients = new Set<ClientWithPagination>();
+
+  wss.on("connection", (ws) => {
+    console.log("Client connected to /stream/orderbook");
+
+    const clientData: ClientWithPagination = {
+      socket: ws,
+      pageIndex: 1,
+      pageSize: 10,
+    };
+
+    clients.add(clientData);
+
+    ws.send(JSON.stringify({ message: "Welcome to orderbook stream!" }));
+
+    ws.on("message", (message: string) => {
+      try {
+        const { pageIndex, pageSize } = JSON.parse(message);
+        if (typeof pageIndex === "number" && typeof pageSize === "number" && pageIndex >= 1 && pageSize >= 1) {
+          clientData.pageIndex = pageIndex;
+          clientData.pageSize = pageSize;
+        }
+      } catch (err) {
+        console.error("Invalid message from client:", message, err);
+      }
+    });
+
+    ws.on("close", () => {
+      clients.delete(clientData);
+      console.log("Client disconnected from /stream/orderbook");
+    });
+
+    ws.on("error", (err) => {
+      console.error("WebSocket error:", err);
+    });
+  });
+
+  setInterval(() => {
+    for (const client of clients) {
+      const { socket, pageIndex, pageSize } = client;
+
+      if (socket.readyState !== socket.OPEN) continue;
+
+      const skip = (pageIndex - 1) * pageSize;
+      const paginatedTokenInfo = tokenInfo?.slice(skip, skip + pageSize);
+
+      const updatedTokenInfo = paginatedTokenInfo.map((token) => {
+        const priceInfo = TokenPriceStore?.find((data) => data.token === getTokenName(token.symbol));
+        return {
+          ...token,
+          price: priceInfo?.price,
+          change_1hr: priceInfo?.change_1hr ?? null,
+          change_1d: priceInfo?.change_1d ?? null,
+          change_1w: priceInfo?.change_1w ?? null,
+          market_cap: priceInfo?.market_cap ?? null,
+          volume_24hr: priceInfo?.volume_24hr ?? null,
+        };
+      });
+
+      const totalPages = Math.ceil(tokenInfo.length / pageSize);
+
+      socket.send(JSON.stringify({ data: updatedTokenInfo, totalPages }));
+    }
+  }, 1000);
+};
+
+// export const handleOrderbookStream = (wss: WebSocketServer) => {
+//   const clients = new Set<WebSocket>();
+
+//   wss.on("connection", (ws) => {
+//     console.log("Client connected to /stream/orderbook");
+//     clients.add(ws);
+
+//     ws.send(JSON.stringify({ message: "Welcome to orderbook stream!" }));
+
+//     ws.on("close", () => {
+//       clients.delete(ws);
+//       console.log("Client disconnected from /stream/orderbook");
+//     });
+
+//     ws.on("error", (err) => {
+//       console.error("WebSocket error:", err);
+//     });
+
+//     setInterval(() => {
+//       const data = JSON.stringify(orderBooksStore);
+//       for (const client of clients) {
+//         if (client.readyState === client.OPEN) {
+//           client.send(data);
+//         }
+//       }
+//     }, 1000);
+//   });
+// };
+
+export const handleOrderbookStream = (wss: WebSocketServer) => {
+  // Keep track of clients and their subscribed token pair
+  const clients = new Map<WebSocket, string>();
+
+  wss.on("connection", (ws, req) => {
+    const { query } = parse(req.url || "", true);
+    const tokenPair = query.pair as string;
+
+    if (!tokenPair) {
+      ws.send(JSON.stringify({ error: "Missing 'pair' query parameter" }));
+      ws.close();
+      return;
+    }
+
+    const normalizedToken = tokenPair.split("_").join("").toLowerCase();
+    clients.set(ws, normalizedToken);
+
+    console.log(`Client connected to /stream/orderbook for pair: ${tokenPair}`);
+
+    ws.send(JSON.stringify({ message: `Subscribed to ${tokenPair} orderbook stream.` }));
+
+    ws.on("close", () => {
+      clients.delete(ws);
+      console.log(`Client disconnected from /stream/orderbook for pair: ${tokenPair}`);
+    });
+
+    ws.on("error", (err) => {
+      console.error("WebSocket error:", err);
+    });
+  });
+
+  setInterval(() => {
+    for (const [client, tokenKey] of clients.entries()) {
+      console.log("tokenKey===================>", tokenKey);
+
+      if (client.readyState === WebSocket.OPEN) {
+        const orderBook = orderBooksStore[tokenKey];
+        if (orderBook) {
+          client.send(JSON.stringify({ [tokenKey]: orderBook }));
+        }
+      }
+    }
+  }, 1000);
+};


### PR DESCRIPTION
- Replaced refetchInterval polling with a WebSocket-based approach.
- WebSocket now streams order book data live for the selected tokenPair.
- Initial order book data is still fetched with useSuspenseQuery to enable SSR hydration.
- Reduces unnecessary network requests and improves user experience with faster, real-time data.